### PR TITLE
Fix inner join query to respect azerothcore `id1` -> `id` rename

### DIFF
--- a/src/flightmaster_whistle.cpp
+++ b/src/flightmaster_whistle.cpp
@@ -41,7 +41,7 @@ void FlightmasterWhistle::LoadFlightmasters()
     uint32 oldMSTime = getMSTime();
 
     QueryResult result = WorldDatabase.Query("select c.guid, c.map, c.position_x, c.position_y, c.position_z, c.orientation from creature_template ct "
-        "inner join creature c on ct.entry = c.id1 "
+        "inner join creature c on ct.entry = c.id "
         "where ct.npcflag & 8192 = 8192");
     if (!result)
     {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Rename `id1` field to `id` in sql query

## Issues Addressed:
```
[1054] Unknown column 'c.id1' in 'on clause'
Your database structure is not up to date. Please make sure you've executed all queries in the sql/updates folders.
```

## SOURCE:


## Tests Performed:
- Tested in-game on Windows.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.